### PR TITLE
feat: add mobile nav menu with hamburger toggle

### DIFF
--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -3,6 +3,7 @@ import {navLinks, resumeLink} from "../constants/index.js";
 
 const NavBar = () => {
     const [scrolled, setScrolled] = useState(false);
+    const [menuOpen, setMenuOpen] = useState(false);
 
     useEffect(() => {
         const handleScroll = () => {
@@ -14,12 +15,29 @@ const NavBar = () => {
         return () => { window.removeEventListener('scroll', handleScroll); }
     }, [])
 
+    // Close the mobile menu on Escape and lock body scroll while it is open.
+    useEffect(() => {
+        if (!menuOpen) return;
 
+        const handleKeyDown = (e) => {
+            if (e.key === 'Escape') setMenuOpen(false);
+        }
+
+        window.addEventListener('keydown', handleKeyDown);
+        document.body.style.overflow = 'hidden';
+
+        return () => {
+            window.removeEventListener('keydown', handleKeyDown);
+            document.body.style.overflow = '';
+        }
+    }, [menuOpen])
+
+    const closeMenu = () => setMenuOpen(false);
 
     return (
-        <header className={`navbar ${scrolled ? 'scrolled' : 'not-scrolled'}`}>
+        <header className={`navbar ${scrolled || menuOpen ? 'scrolled' : 'not-scrolled'}`}>
             <div className="inner">
-                <a className="logo" href="#hero">
+                <a className="logo" href="#hero" onClick={closeMenu}>
                     Krishna Gandhi
                 </a>
                 <nav className="desktop">
@@ -45,7 +63,45 @@ const NavBar = () => {
                         <span>Contact me</span>
                     </div>
                 </a>
+                <button
+                    type="button"
+                    className="menu-toggle"
+                    aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+                    aria-expanded={menuOpen}
+                    aria-controls="mobile-menu"
+                    onClick={() => setMenuOpen((open) => !open)}
+                >
+                    <span className={`menu-icon ${menuOpen ? 'open' : ''}`}>
+                        <span />
+                        <span />
+                        <span />
+                    </span>
+                </button>
             </div>
+
+            <nav
+                id="mobile-menu"
+                className={`mobile-menu ${menuOpen ? 'open' : ''}`}
+                aria-hidden={!menuOpen}
+            >
+                <ul>
+                    {navLinks.map(({link, name}) => (
+                        <li key={name}>
+                            <a href={link} onClick={closeMenu}>{name}</a>
+                        </li>
+                    ))}
+                    <li>
+                        <a href={resumeLink} target="_blank" rel="noreferrer" onClick={closeMenu}>
+                            Resume
+                        </a>
+                    </li>
+                    <li>
+                        <a href="#contact" className="mobile-contact" onClick={closeMenu}>
+                            Contact me
+                        </a>
+                    </li>
+                </ul>
+            </nav>
         </header>
     )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -142,13 +142,57 @@ section {
         }
 
         .contact-btn {
-            @apply flex;
+            @apply hidden lg:flex;
 
             .inner {
                 @apply px-5 py-2 rounded-lg bg-white text-black group-hover:bg-black-50 transition-colors duration-300;
 
                 span {
                     @apply group-hover:text-white transition-colors duration-300;
+                }
+            }
+        }
+
+        .menu-toggle {
+            @apply flex lg:hidden items-center justify-center w-10 h-10 cursor-pointer;
+
+            .menu-icon {
+                @apply relative flex flex-col justify-between w-6 h-[18px];
+
+                span {
+                    @apply block h-0.5 w-full bg-white-50 rounded-full origin-center transition-all duration-300;
+                }
+
+                &.open span:nth-child(1) {
+                    @apply translate-y-[8px] rotate-45;
+                }
+
+                &.open span:nth-child(2) {
+                    @apply opacity-0;
+                }
+
+                &.open span:nth-child(3) {
+                    @apply -translate-y-[8px] -rotate-45;
+                }
+            }
+        }
+
+        .mobile-menu {
+            @apply lg:hidden overflow-hidden max-h-0 opacity-0 transition-all duration-300 ease-in-out;
+
+            &.open {
+                @apply max-h-[420px] opacity-100 mt-4;
+            }
+
+            ul {
+                @apply flex flex-col gap-1 bg-black rounded-xl p-4;
+
+                li a {
+                    @apply block text-white-50 text-lg py-3 px-3 rounded-lg transition-colors duration-300 hover:bg-black-50 hover:text-white;
+                }
+
+                .mobile-contact {
+                    @apply mt-2 bg-white text-black text-center font-medium hover:bg-black-50 hover:text-white;
                 }
             }
         }


### PR DESCRIPTION
Below the lg breakpoint the navbar previously showed only the logo and contact button, leaving Work/Experience/Skills/Resume unreachable. Add a hamburger toggle that opens a dropdown panel with all nav links plus Resume and Contact.

Includes an animated hamburger-to-X icon, Escape-to-close, body scroll lock while open, and aria attributes for accessibility.