### PR TITLE
fix: cap experience card image height so the GSoC logo isn't oversized

### DIFF
--- a/src/sections/ExperienceSection.jsx
+++ b/src/sections/ExperienceSection.jsx
@@ -70,9 +70,9 @@ const ExperienceSection = () => {
                                 <div className="xl:w-2/6">
                                     <GlowCard card={card}>
                                         <div>
-                                            <img src={card.imgPath} alt="exp-img" loading="lazy" />
+                                            <img src={card.imgPath} alt="exp-img" loading="lazy" className="w-full max-h-44 object-contain" />
                                             {card.img1Path ? (
-                                                <img src={card.img1Path} alt="exp-img" loading="lazy" />
+                                                <img src={card.img1Path} alt="exp-img" loading="lazy" className="w-full max-h-44 object-contain" />
                                             ) : null}
                                         </div>
                                     </GlowCard>


### PR DESCRIPTION
The GSoC image is a 1024x1024 square while the other experience cards use short landscape banners, so it rendered as a giant block. Adds w-full max-h-44 object-contain to the card images to keep a consistent height without distortion.