### PR TITLE
fix: register ScrollTrigger plugin in TechStack

### DIFF
--- a/src/sections/TechStack.jsx
+++ b/src/sections/TechStack.jsx
@@ -1,9 +1,12 @@
 import { useGSAP } from "@gsap/react";
 import gsap from "gsap";
+import { ScrollTrigger } from "gsap/ScrollTrigger";
 
 import TitleHeader from "../components/TitleHeader";
 import {techStackImgs} from "../constants";
 // import { techStackImgs } from "../constants";
+
+gsap.registerPlugin(ScrollTrigger);
 
 const TechStack = () => {
     // Animate the tech cards in the skills section


### PR DESCRIPTION
TechStack.jsx uses ScrollTrigger animations but never registered the plugin itself; it worked only because another section registered it first at import time. Register it at module scope so the file is self-contained and not dependent on import order.